### PR TITLE
fix swagger UI package to allow compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "react-trafficlight": "^5.2.1",
     "superagent": "^7.1.2",
-    "swagger-ui-react": "^4.10.3",
+    "swagger-ui-react": "4.13.0",
     "typescript": "^4.6.3",
     "xstate": "^4.31.0"
   },


### PR DESCRIPTION
Compilation failed with
```
Failed to compile.  
./node_modules/swagger-ui-react/swagger-ui-es-bundle-core.js 13083:23 
Module parse failed: Unexpected token (13083:23) 
File was processed with these loaders:  * ./node_modules/babel-loader/lib/index.js
...
```

Fixed by pinning the Swagger UI package to version 4.13.0 as recommended here:
https://github.com/swagger-api/swagger-ui/issues/8062